### PR TITLE
Support class directives in dictionary table export.

### DIFF
--- a/Rant/Vocabulary/RantDictionaryTable.Exporter.cs
+++ b/Rant/Vocabulary/RantDictionaryTable.Exporter.cs
@@ -36,19 +36,137 @@ namespace Rant.Vocabulary
 
         private static void WriteEntries(StreamWriter writer, IEnumerable<RantDictionaryEntry> entries)
         {
-            foreach (var entry in entries)
-            {
-                writer.WriteLine("> {0}", entry.Terms.Select(t => t.Value).Aggregate((c, n) => c + "/" + n));
+			var root = new RantDictionaryTableClassDirective("root");
+			// we create the tree of class directives first - then we fill it
+			List<string[]> classes = entries.Select(x =>
+			{
+				return x.GetClasses().ToArray();
+			}).ToList();
+			CreateNestedClassDirectives(root, classes);
+			
+			// now that we have a tree of class directives, let's populate it
+			entries.ToList().ForEach(entry =>
+			{
+				if(entry.GetClasses().Count() == 0) return;
+				var directive = root.FindDirectiveForClasses(entry.GetClasses().ToArray());
+				if(directive != null)
+					directive.Entries.Add(entry);
+			});
 
-                if (!String.IsNullOrWhiteSpace(entry.Terms[0].Pronunciation))
-                    writer.WriteLine("  | pron {0}", entry.Terms.Select(t => t.Pronunciation).Aggregate((c, n) => c + "/" + n));
-
-                if (entry.GetClasses().Any())
-                    writer.WriteLine("  | class {0}", entry.GetClasses().Aggregate((c, n) => c + " " + n));
-
-                if (entry.Weight != 1)
-                    writer.WriteLine("  | weight {0}", entry.Weight);
-            }
+			root.Render(writer);
         }
+
+		// thank you stack exchange
+		// http://programmers.stackexchange.com/q/267495/161632
+		private static void CreateNestedClassDirectives(RantDictionaryTableClassDirective parent, List<string[]> entries)
+		{
+			Dictionary<string, int> classCounts = new Dictionary<string, int>();
+
+			entries.ForEach(x =>
+			{
+				int count;
+				for(int i = 0; i < x.Length; i++)
+					classCounts[x[i]] = classCounts.TryGetValue(x[i], out count) ? count + 1 : 1;
+			});
+
+			// do this again with children of this class
+			string bestClass = classCounts.OrderByDescending(x => x.Value).First().Key;
+			if(classCounts[bestClass] <= 3) return;
+			var bestDirective = new RantDictionaryTableClassDirective(bestClass);
+			bestDirective.Parent = parent;
+			var childEntries = entries
+				.Where(x => x.Contains(bestClass) && x.Length > 1)
+				.Select(x =>
+				{
+					// remove bestClass from array
+					return x.Where(y => y != bestClass).ToArray();
+				})
+				.ToList();
+			if(childEntries.Count > 0)
+				CreateNestedClassDirectives(bestDirective, childEntries);
+			parent.Children[bestClass] = bestDirective;
+
+			// for things that aren't children of this class
+			var otherEntries = entries
+				.Where(x => !x.Contains(bestClass) && x.Length > 0)
+				.ToList();
+			if(otherEntries.Count > 0)
+				CreateNestedClassDirectives(parent, otherEntries);
+		}
+
+		private class RantDictionaryTableClassDirective
+		{
+			public string Name;
+			public Dictionary<string, RantDictionaryTableClassDirective> Children;
+			public RantDictionaryTableClassDirective Parent;
+			public List<RantDictionaryEntry> Entries;
+
+			public string[] Classes
+			{
+				get
+				{
+					if(Parent == null) return new string[] { };
+					var classes = new List<string>() { this.Name };
+					classes.AddRange(Parent.Classes);
+					return classes.ToArray();
+				}
+			}
+
+			public RantDictionaryTableClassDirective(string name)
+			{
+				this.Name = name;
+				this.Entries = new List<RantDictionaryEntry>();
+				this.Children = new Dictionary<string, RantDictionaryTableClassDirective>();
+			}
+
+			public RantDictionaryTableClassDirective FindDirectiveForClasses(string[] classes)
+			{
+				foreach(var c in classes)
+				{
+					if(Children.ContainsKey(c))
+					{
+						if(classes.Length == 1) return Children[c];
+						var tree = Children[c].FindDirectiveForClasses(classes.Where(x => x != c).ToArray());
+						if(tree != null) return tree;
+					}
+				}
+				return null;
+			}
+
+			public void Render(StreamWriter writer, int level = -1)
+			{
+				string leadingWhitespace = "";
+				string leadingWhitespacer = (Parent != null ? "  " : "");
+				for(var i = 0; i < level; i++)
+				{
+					leadingWhitespacer += "  ";
+					leadingWhitespace += "  ";
+				}
+
+				if(Parent != null)
+					writer.WriteLine(leadingWhitespace + "#class add " + this.Name);
+
+				foreach(string key in this.Children.Keys)
+					this.Children[key].Render(writer, level + 1);
+
+				foreach(RantDictionaryEntry entry in Entries)
+				{
+					writer.WriteLine(leadingWhitespacer + "> {0}", entry.Terms.Select(t => t.Value).Aggregate((c, n) => c + "/" + n));
+
+					if(!String.IsNullOrWhiteSpace(entry.Terms[0].Pronunciation))
+						writer.WriteLine(leadingWhitespacer + "  | pron {0}", entry.Terms.Select(t => t.Pronunciation).Aggregate((c, n) => c + "/" + n));
+
+					string[] uniqueClasses = entry.GetClasses().Where(x => !Classes.Contains(x)).ToArray();
+					if(uniqueClasses.Length > 0)
+						writer.WriteLine(leadingWhitespacer + "  | class {0}", uniqueClasses.Aggregate((c, n) => c + " " + n));
+
+					if(entry.Weight != 1)
+						writer.WriteLine(leadingWhitespacer + "  | weight {0}", entry.Weight);
+				}
+
+				if(Parent != null)
+					writer.WriteLine(leadingWhitespace + "#class remove " + this.Name + "\n");
+			}
+		}
     }
 }


### PR DESCRIPTION
I've finally (with the help of [Stack Exchange](http://programmers.stackexchange.com/q/267495/161632)) managed to create a way to regenerate class directives when exporting dictionary tables. It essentially generates a tree of class directives based on the method described in the Stack Exchange question I linked before, and then populates them with the dictionary entries. It's a whole bunch of recursion and Rohan would probably cry but it works (as far as I can tell)!
