### PR TITLE
Precompute RantPattern tokens for huge perf boost

### DIFF
--- a/Rant/RantPattern.cs
+++ b/Rant/RantPattern.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
-using Rant.Engine;
 using Rant.Engine.Compiler;
 using Rant.Engine.Constructs;
 using Rant.Stringes;
@@ -54,7 +53,7 @@ namespace Rant
             _type = type;
             _code = code;
             _stringe = code.ToStringe();
-            _tokens = RantLexer.GenerateTokens(_stringe);
+            _tokens = RantLexer.GenerateTokens(_stringe).ToList();
         }
 
         internal RantPattern(RantPattern derived, IEnumerable<Token<R>> sub)


### PR DESCRIPTION
RantPattern's constructor uses GenerateTokens to split the given pattern into a lazy sequence of lexer tokens. When RantEngine.Do is called, it creates a new VM, which creates a new RantState, which creates a new PatternReader, which finally evaluates the given pattern's token sequence using .ToArray(). However, the results of the evaluation are not cached (IEnumerable won't do that automatically). This makes using RantPattern.FromString/FromFile mostly useless, since the pattern is parsed again and again for each iteration.

The performance issue is fixed by calling .ToList() after GenerateTokens in RantPattern's constructor. This patch improves pattern evaluation performance by at least 15-25x in synthetic benchmarks.
