### PR TITLE
Console: fix crash on input EOF/redirection

### DIFF
--- a/Rant.Console/Program.cs
+++ b/Rant.Console/Program.cs
@@ -106,7 +106,11 @@ namespace RantConsole
                 ForegroundColor = Flag("nsfw") ? ConsoleColor.DarkRed : ConsoleColor.Gray;
                 Write("RANT> "); // real number symbol
                 ForegroundColor = ConsoleColor.White;
-                PrintOutput(rant, ReadLine());
+                string input = ReadLine();
+                if(input == null) {
+                    return;
+                }
+                PrintOutput(rant, input);
             }
         }
 


### PR DESCRIPTION
The Rant console currently crashes when the standard input is either manually closed (e.g. CTRL+D in a linux terminal) or redirected. This happens because the input loop doesn't check for EOF, and as a result can pass a null string to `PrintOutput`.

The fix checks whether the string returned by `Console.ReadLine` is null, and returns gracefully if so.